### PR TITLE
Revert to "Added streaming layer" match because DE is DE

### DIFF
--- a/CascadeTileScanner.py
+++ b/CascadeTileScanner.py
@@ -121,7 +121,7 @@ class Overlay:
                     if not searching and ("/Lotus/Levels/Proc/TheNewWar/PartTwo/TNWDrifterCampMain" in line or "/Lotus/Levels/Proc/PlayerShip" in line):
                         self.update_overlay("Awaiting Cascade...", "red")
                         
-                    if "TacticalAreaMap::AddZone /Lotus/Levels/Zariman/" in line:
+                    if "Added streaming layer /Lotus/Levels/Zariman/" in line:
                         for key in sorted(tilesets.keys(), key=len, reverse=True):
                             if key in line:
                                 tilecount += 1
@@ -154,7 +154,7 @@ class Overlay:
                         if not loadedMessage:
                             tiles = ""
                             exocount = 0
-                        tilesets = original_tilesets.copy()
+                        tilesets = original_tilesets.copy()  # Reset the tilesets after 3 tiles found
                     
 if __name__ == '__main__':
     overlay = Overlay()


### PR DESCRIPTION
DE decided to get rid of the logging message "TacticalAreaMap::AddZone" that was used alternatively to the added streaming layer message, really cool.